### PR TITLE
fix rp2040 with new shared irq usb handler

### DIFF
--- a/ports/raspberrypi/supervisor/usb.c
+++ b/ports/raspberrypi/supervisor/usb.c
@@ -39,15 +39,8 @@ STATIC void _usb_irq_wrapper(void) {
 }
 
 void post_usb_init(void) {
-    irq_set_enabled(USBCTRL_IRQ, false);
-
-    irq_handler_t usb_handler = irq_get_exclusive_handler(USBCTRL_IRQ);
-    if (usb_handler) {
-        irq_remove_handler(USBCTRL_IRQ, usb_handler);
-    }
-    irq_set_exclusive_handler(USBCTRL_IRQ, _usb_irq_wrapper);
-
-    irq_set_enabled(USBCTRL_IRQ, true);
+    irq_add_shared_handler(USBCTRL_IRQ, _usb_irq_wrapper,
+        PICO_SHARED_IRQ_HANDLER_LOWEST_ORDER_PRIORITY);
 
     // There is a small window where the USB interrupt may be handled by the
     // pico-sdk instead of CircuitPython. If that is the case, then we'll have

--- a/supervisor/shared/usb/usb.c
+++ b/supervisor/shared/usb/usb.c
@@ -225,13 +225,17 @@ void usb_background_schedule(void) {
 }
 
 void usb_irq_handler(int instance) {
+    #if CFG_TUSB_MCU != OPT_MCU_RP2040
+    // For rp2040, IRQ handler is already installed and invoked automatically
     if (instance == CIRCUITPY_USB_DEVICE_INSTANCE) {
         tud_int_handler(instance);
-    } else if (instance == CIRCUITPY_USB_HOST_INSTANCE) {
-        #if CIRCUITPY_USB_HOST
-        tuh_int_handler(instance);
-        #endif
     }
+    #if CIRCUITPY_USB_HOST
+    else if (instance == CIRCUITPY_USB_HOST_INSTANCE) {
+        tuh_int_handler(instance);
+    }
+    #endif
+    #endif
 
     usb_background_schedule();
 }


### PR DESCRIPTION
due to https://github.com/hathach/tinyusb/pull/1519, rp2040 irq handler is now shared one, unlike exclusive one, we cannot get and remove shared handler declared static by tinyusb. We could simply
- add new shared irq to schedule usb background
- skip calling tud/tuh_int_handler with rp2040. 

@dhalbert